### PR TITLE
LargeImage Component changes when thumbnail is clicked

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,19 +7,32 @@ import Thumbnails from './Thumbnails';
 //Import LargeImage component
 import LargeImage from './LargeImage';
 //Import images object
-//import { images } from './modules/object.js';
+import { images } from './modules/object.js';
 
 function App() {
   //useState declaration for setting the active border class on the thumbnail image
-  const [isActive, setIsActive] = useState()
+  const [isActive, setIsActive] = useState();
+  //useState declaration for setting the LargeImage Component's src attribute
+  const [src, setSrc] = useState(images.antelopes.src);
+  //useState declaration for setting the LargeImage Component's alt attribute
+  const [alt, setAlt] = useState(images.antelopes.alt);
+  //useState declaration for setting the LargeImage Component's corresponding caption
+  const [caption, setCaption] = useState(images.antelopes.caption);
+
+  //LargeImage handler function to control the src, alt attributes and corresponding caption
+  const largeImageHandler = (newImage) => {
+    setSrc(images[newImage].src);
+    setAlt(images[newImage].alt);
+    setCaption(images[newImage].caption);
+  }
 
   return (
     <section id="wrapper">
       <div className="container">
         <h1>Amazing Animal Photos</h1>
       </div>
-      <Thumbnails activeClass={isActive} toggleClass={setIsActive}/>
-      <LargeImage />
+      <Thumbnails activeClass={isActive} toggleClass={setIsActive} largeImageHandle={largeImageHandler}/>
+      <LargeImage src={src} alt={alt} caption={caption}/>
     </section>
   );
 }

--- a/src/Thumbnails.js
+++ b/src/Thumbnails.js
@@ -24,9 +24,11 @@ function Thumbnails(props) {
                     role='button'
                     height='19.5%'
                     width='19.5%'
-                    onClick={() =>
-                        props.toggleClass(thumbnail.id)
-                    }
+                    onClick={({target}) => {
+                        const selectedImage = target.alt;
+                        props.largeImageHandle(selectedImage);
+                        props.toggleClass(thumbnail.id);
+                    }}
                 />
             ))}
         </figure>


### PR DESCRIPTION
Added 3 `useState` hooks to handle the the `src` and `alt` attributes of the *LargeImage* Component's rendered `<img/>` as well as the matching each image with a corresponding caption.

All states were assigned as `props` to the *LargeImage Component* and their setter functions were used in a handler function that accepted `newImage` as an argument. The handler function was passed to the *Thumbnail Component* as a prop and used in the `onClick` function with the declared variable `selectedImage` as it's param. 